### PR TITLE
docs: documentar instalação e execução

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,28 @@ cd ConstroiVerse
 python3 -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
+```
+
+## ▶️ Execução
+
+### Backend Flask
+
+```bash
+python main.py
+```
+
+### Servidor Node (opcional)
+
+```bash
+node backend/server.js
+```
+
+## 🔐 Variáveis de ambiente
+
+Antes de executar a aplicação, defina as seguintes variáveis de ambiente:
+
+- `SECRET_KEY`: chave secreta usada pelo Flask para assinar tokens.
+- `MONGO_URI`: string de conexão com o MongoDB.
+- `OPENAI_API_KEY`: chave de acesso à API da OpenAI.
+- `JWT_SECRET`: (se usar o servidor Node) segredo para assinar tokens JWT.
+- `PORT`: porta utilizada pelo servidor Node.


### PR DESCRIPTION
## Summary
- close missing code block in installation instructions
- document how to run Flask backend and optional Node server
- list required environment variables

## Testing
- `pytest` *(fails: IndentationError in backend/app.py)*

------
https://chatgpt.com/codex/tasks/task_e_6897dbdc1d848329b6984fea045ba034