### PR TITLE
feat: add user registration

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -1,3 +1,40 @@
+const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
+const User = require('../models/User');
+
+exports.register = async (req, res) => {
+  try {
+    const { name, email, password, mainProfile } = req.body;
+    const hashedPassword = await bcrypt.hash(password, 10);
+
+    const user = await User.create({
+      name,
+      email,
+      password: hashedPassword,
+      mainProfile,
+      role: 'user',
+      permissions: []
+    });
+
+    const token = jwt.sign(
+      { id: user._id, mainProfile: user.mainProfile, role: user.role, permissions: user.permissions },
+      process.env.JWT_SECRET,
+      { expiresIn: '12h' }
+    );
+
+    res.status(201).json({
+      sucesso: true,
+      token,
+      redirect: `/painel/${user.mainProfile}`,
+      perfil: user.mainProfile,
+      role: user.role,
+      permissions: user.permissions
+    });
+  } catch (err) {
+    res.status(500).json({ sucesso: false, erro: err.message });
+  }
+};
+
 exports.login = async (req, res) => {
   try {
     const { email, password } = req.body;
@@ -26,3 +63,9 @@ exports.login = async (req, res) => {
     res.status(500).json({ sucesso: false, erro: err.message });
   }
 };
+
+module.exports = {
+  register: exports.register,
+  login: exports.login
+};
+


### PR DESCRIPTION
## Summary
- add user registration with password hashing and JWT issuance
- expose register and login controller exports

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest` *(fails: IndentationError: unexpected indent)*

------
https://chatgpt.com/codex/tasks/task_e_6897dbde53588329a2bd14e9ceed0b83